### PR TITLE
Create MenuMode and add more fundamental screen switching

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -1,5 +1,35 @@
 {
 	"textures": {
+        "loading-background": {
+          "file":     "images/background.png",
+          "minFilter": "linear",
+          "magFilter": "linear"
+        },
+        "title": {
+          "file": "images/title_v1.png",
+          "minFilter": "linear",
+          "magFilter": "linear"
+        },
+        "ghost-cat": {
+          "file": "images/ghost_cat.jpg",
+          "minFilter": "linear",
+          "maxFilter": "linear"
+        },
+        "play-old": {
+          "file": "images/play.png",
+          "minFilter": "linear",
+          "maxFilter": "linear"
+        },
+        "play": {
+          "file":     "images/play_button_v1.png",
+          "minFilter": "linear",
+          "magFilter": "linear"
+        },
+        "level-editor": {
+          "file": "images/leveleditor_button_v1.png",
+          "minFilter": "linear",
+          "maxFilter": "linear"
+        },
         "background": "images/background.png",
         "concert-background": "images/backgrounds/background_temp_concert_1.png",
         "street-background": "images/backgrounds/background_temp_streets_1.png",

--- a/core/src/edu/cornell/gdiac/temporary/CalibrationMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/CalibrationMode.java
@@ -92,7 +92,7 @@ public class CalibrationMode implements Screen {
     public void populate(AssetDirectory directory) {
         displayFont = directory.getEntry("times", BitmapFont.class);
         music = directory.getEntry("calibration", MusicQueue.class);
-        background  = directory.getEntry("background",Texture.class); //calibration background?
+        background  = directory.getEntry("background", Texture.class); //calibration background?
     }
 
     @Override
@@ -101,7 +101,7 @@ public class CalibrationMode implements Screen {
             update(delta);
             draw(delta);
             if (isReady() && listener != null) {
-                listener.exitScreen(this, 0);
+                listener.exitScreen(this, MenuMode.TO_MENU);
             }
         }
     }
@@ -111,8 +111,8 @@ public class CalibrationMode implements Screen {
         canvas.begin();
         canvas.drawBackground(background,0,0);
 
-        // draw a hit bar
-        // Change line color if it is triggered
+        //        // draw a hit bar
+//        // Change line color if it is triggered
         Color lineColor = inputController.didHoldPlay() ? Color.TEAL : Color.NAVY;
         canvas.drawLine(canvas.getWidth()/2-canvas.getWidth()/12, canvas.getHeight()/2, canvas.getWidth()/2-canvas.getWidth()/12+(canvas.getWidth()/6), canvas.getHeight()/2, 200, lineColor);
 

--- a/core/src/edu/cornell/gdiac/temporary/CalibrationMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/CalibrationMode.java
@@ -101,7 +101,7 @@ public class CalibrationMode implements Screen {
             update(delta);
             draw(delta);
             if (isReady() && listener != null) {
-                listener.exitScreen(this, MenuMode.TO_MENU);
+                listener.exitScreen(this, ExitCode.TO_MENU);
             }
         }
     }
@@ -111,8 +111,8 @@ public class CalibrationMode implements Screen {
         canvas.begin();
         canvas.drawBackground(background,0,0);
 
-        //        // draw a hit bar
-//        // Change line color if it is triggered
+        // draw a hit bar
+        // Change line color if it is triggered
         Color lineColor = inputController.didHoldPlay() ? Color.TEAL : Color.NAVY;
         canvas.drawLine(canvas.getWidth()/2-canvas.getWidth()/12, canvas.getHeight()/2, canvas.getWidth()/2-canvas.getWidth()/12+(canvas.getWidth()/6), canvas.getHeight()/2, 200, lineColor);
 

--- a/core/src/edu/cornell/gdiac/temporary/ExitCode.java
+++ b/core/src/edu/cornell/gdiac/temporary/ExitCode.java
@@ -1,0 +1,20 @@
+package edu.cornell.gdiac.temporary;
+
+/**
+ * This class contains exit codes for screen switching.
+ * The format is TO_[mode], where mode is the mode (maybe not necessarily a controller class) you are going to
+ * The number should not conflict with anything else (i.e. don't make variables the same number)
+ * Whenever you need to add a state to switch to, add it here
+ */
+public class ExitCode {
+    // exit out of game
+    public static final int TO_EXIT = 0;
+    // exit to playing
+    public static final int TO_PLAYING = 1;
+    // exit to calibration mode
+    public static final int TO_CALIBRATION = 2;
+    // exit to editor
+    public static final int TO_EDITOR = 3;
+    // exit to menu
+    public static final int TO_MENU = 4;
+}

--- a/core/src/edu/cornell/gdiac/temporary/GDXRoot.java
+++ b/core/src/edu/cornell/gdiac/temporary/GDXRoot.java
@@ -137,8 +137,7 @@ public class GDXRoot extends Game implements ScreenListener {
 	 * @param exitCode The state of the screen upon exit
 	 */
 	public void exitScreen(Screen screen, int exitCode) {
-		System.out.println("exiting: " + screen + " " + exitCode);
-		if (screen == loading) {
+		if (screen == loading && exitCode == ExitCode.TO_MENU) {
 			directory = loading.getAssets();
 			menu.setScreenListener(this);
 			menu.populate(directory);
@@ -176,8 +175,8 @@ public class GDXRoot extends Game implements ScreenListener {
 			// We quit the main application
 			Gdx.app.exit();
 		} else {
-			 Gdx.app.error("GDXRoot", "Exit with error code "+exitCode, new RuntimeException());
-			 Gdx.app.exit();
+			Gdx.app.error("GDXRoot", "Exit with error code "+exitCode, new RuntimeException());
+			Gdx.app.exit();
 		}
 	}
 

--- a/core/src/edu/cornell/gdiac/temporary/GDXRoot.java
+++ b/core/src/edu/cornell/gdiac/temporary/GDXRoot.java
@@ -23,9 +23,6 @@ import edu.cornell.gdiac.temporary.editor.*;
 import com.badlogic.gdx.*;
 import edu.cornell.gdiac.assets.*;
 
-import java.awt.*;
-import java.io.FileNotFoundException;
-
 import java.io.IOException;
 
 /**
@@ -132,6 +129,7 @@ public class GDXRoot extends Game implements ScreenListener {
 	
 	/**
 	 * The given screen has made a request to exit its player mode.
+	 * This is where most of the screen switching logic is done.
 	 *
 	 * The value exitCode can be used to implement menu options.
 	 *
@@ -147,52 +145,40 @@ public class GDXRoot extends Game implements ScreenListener {
 			setScreen(menu);
 			loading.dispose();
 			loading = null;
-		} else if (exitCode == 1 && screen == menu) {
-			System.out.println("leaving menu");
-			if (menu.getPressState() == MenuMode.TO_GAME) {
-				playing.setScreenListener(this);
-				playing.readLevel(directory);
-				playing.populate(directory);
-				playing.initializeOffset(calibration.getOffset());
-				setScreen(playing);
-			} else if (menu.getPressState() == MenuMode.TO_LEVEL_EDITOR) {
-				editing.setScreenListener(this);
-				editing.populate(directory);
-				setScreen(editing);
-				editing.show();
-			} else if (menu.getPressState() == MenuMode.TO_CALIBRATION) {
-				calibration.setScreenListener(this);
-				calibration.populate(directory);
-				setScreen(calibration);
-				calibration.show();
-			}
-			menu.reset();
-			menu.hide();
-		} else if (exitCode == MenuMode.TO_MENU) {
-			System.out.println("going back to menu");
-			if (screen == playing)
-				playing.hide();
-			else if (screen == editing) {
-				System.out.println("leaving editing");
-				editing.hide();
-			}
-			else {
-				calibration.hide();
-				System.out.println(calibration.getOffset());
-			}
+		} else if (exitCode == ExitCode.TO_PLAYING) {
+			screen.hide();
+			playing.setScreenListener(this);
+			playing.readLevel(directory);
+			playing.populate(directory);
+			playing.initializeOffset(calibration.getOffset());
+			setScreen(playing);
+			playing.show();
+		} else if (exitCode == ExitCode.TO_EDITOR) {
+			screen.hide();
+			editing.setScreenListener(this);
+			editing.populate(directory);
+			setScreen(editing);
+			editing.show();
+		} else if (exitCode == ExitCode.TO_CALIBRATION) {
+			screen.hide();
+			calibration.setScreenListener(this);
+			calibration.populate(directory);
+			setScreen(calibration);
+			calibration.show();
+		} else if (exitCode == ExitCode.TO_MENU) {
+			System.out.println(calibration.getOffset());
+			screen.hide();
 			menu.setScreenListener(this);
 			setScreen(menu);
 			menu.reset();
 			menu.show();
-		}
-		else {
+		} else if (exitCode == ExitCode.TO_EXIT) {
 			// We quit the main application
 			Gdx.app.exit();
+		} else {
+			 Gdx.app.error("GDXRoot", "Exit with error code "+exitCode, new RuntimeException());
+			 Gdx.app.exit();
 		}
-
-		// errors here
-		// Gdx.app.error("GDXRoot", "Exit with error code "+exitCode, new RuntimeException());
-		//			Gdx.app.exit();
 	}
 
 }

--- a/core/src/edu/cornell/gdiac/temporary/GameMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameMode.java
@@ -273,7 +273,7 @@ public class GameMode implements Screen {
 			update(delta);
 			draw();
 			if (inputController.didExit() && listener != null) {
-				listener.exitScreen(this, MenuMode.TO_MENU);
+				listener.exitScreen(this, ExitCode.TO_MENU);
 			}
 		}
 	}

--- a/core/src/edu/cornell/gdiac/temporary/GameMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameMode.java
@@ -273,7 +273,7 @@ public class GameMode implements Screen {
 			update(delta);
 			draw();
 			if (inputController.didExit() && listener != null) {
-				listener.exitScreen(this, 0);
+				listener.exitScreen(this, MenuMode.TO_MENU);
 			}
 		}
 	}

--- a/core/src/edu/cornell/gdiac/temporary/LoadingMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/LoadingMode.java
@@ -186,7 +186,8 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	 * @return true if the player is ready to go
 	 */
 	public boolean isReady() {
-		return pressState == TO_GAME || pressState == TO_LEVEL_EDITOR || pressState == TO_CALIBRATION;
+//		return pressState == TO_GAME || pressState == TO_LEVEL_EDITOR || pressState == TO_CALIBRATION;
+		return progress >= 1.0f;
 	}
 
 	/**
@@ -298,19 +299,19 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	 * @param delta Number of seconds since last animation frame
 	 */
 	private void update(float delta) {
-		if (playButton == null || levelEditorButton == null) {
+//		if (playButton == null || levelEditorButton == null) {
 			assets.update(budget);
 			this.progress = assets.getProgress();
-			if (progress >= 1.0f) {
-				this.progress = 1.0f;
-				playButton = internal.getEntry("play",Texture.class);
-				levelEditorButton = internal.getEntry("level-editor",Texture.class);
-				calibrationButton = internal.getEntry("play-old",Texture.class);
-				playButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2 + 200);
-				levelEditorButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2);
-				calibrationButtonCoords = new Vector2(centerX + calibrationButton.getWidth()*2 , centerY);
-			}
-		}
+//			if (progress >= 1.0f) {
+//				this.progress = 1.0f;
+//				playButton = internal.getEntry("play",Texture.class);
+//				levelEditorButton = internal.getEntry("level-editor",Texture.class);
+//				calibrationButton = internal.getEntry("play-old",Texture.class);
+//				playButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2 + 200);
+//				levelEditorButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2);
+//				calibrationButtonCoords = new Vector2(centerX + calibrationButton.getWidth()*2 , centerY);
+//			}
+//		}
 	}
 
 	/**
@@ -494,6 +495,8 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	 * @return whether to hand the event to other listeners. 
 	 */
 	public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+		System.out.println("touched");
+
 		if (playButton == null || pressState == TO_GAME || pressState == TO_LEVEL_EDITOR || pressState == TO_CALIBRATION) {
 			return true;
 		}

--- a/core/src/edu/cornell/gdiac/temporary/LoadingMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/LoadingMode.java
@@ -26,15 +26,8 @@ import com.badlogic.gdx.*;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.*;
-import com.badlogic.gdx.controllers.Controller;
-import com.badlogic.gdx.controllers.ControllerListener;
-import com.badlogic.gdx.controllers.ControllerMapping;
-
-import com.badlogic.gdx.math.Vector2;
 import edu.cornell.gdiac.assets.*;
 import edu.cornell.gdiac.util.*;
-
-import java.util.logging.Level;
 
 /**
  * Class that provides a loading screen for the state of the game.
@@ -49,28 +42,16 @@ import java.util.logging.Level;
  * the application.  That is why we try to have as few resources as possible for this
  * loading screen.
  */
-public class LoadingMode implements Screen, InputProcessor, ControllerListener {
+public class LoadingMode implements Screen {
 	// There are TWO asset managers.  One to load the loading screen.  The other to load the assets
 	/** Internal assets for this loading screen */
 	private AssetDirectory internal;
 	/** The actual assets to be loaded */
 	private AssetDirectory assets;
-	
+
 	/** Background texture for start-up */
 	private Texture background;
-	/** Play button to display when done */
-	private Texture playButton;
-	private Texture calibrationButton;
 
-	/** Texture atlas to support a progress bar */
-	private Texture statusBar;
-
-	/** Tempo-Rary logo */
-	private Texture title;
-
-	/** button to transition to level editor */
-	private Texture levelEditorButton;
-	
 	// statusBar is a "texture atlas." Break it up into parts.
 	/** Left cap to the status background (grey region) */
 	private TextureRegion statusBkgLeft;
@@ -129,29 +110,6 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	/** Whether or not this player mode is still active */
 	private boolean active;
 
-	/* BUTTON LOCATIONS */
-	/** Play button x and y coordinates represented as a vector */
-	private Vector2 playButtonCoords;
-	/** Level editor button x and y coordinates represented as a vector */
-	private Vector2 levelEditorButtonCoords;
-	/** Calibration button x and y coordinates represented as a vector */
-	private Vector2 calibrationButtonCoords;
-
-	/* PRESS STATES **/
-	// TODO: potentially change this to enums
-	/** Initial button state */
-	private static final int INITIAL = 0;
-	/** Pressed down button state for the play button */
-	private static final int PLAY_PRESSED = 1;
-	/** Exit code for button to go to the game */
-	public static final int TO_GAME = 2;
-	/** Pressed down button state for the level editor button */
-	private static final int LEVEL_EDITOR_PRESSED = 3;
-	/** Exit code for the button to go to the level editor */
-	public static final int TO_LEVEL_EDITOR = 4;
-	/** Exit code for the button to go to the level editor */
-	public static final int TO_CALIBRATION = 5;
-
 	/**
 	 * Returns the budget for the asset loader.
 	 *
@@ -186,7 +144,6 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	 * @return true if the player is ready to go
 	 */
 	public boolean isReady() {
-//		return pressState == TO_GAME || pressState == TO_LEVEL_EDITOR || pressState == TO_CALIBRATION;
 		return progress >= 1.0f;
 	}
 
@@ -237,15 +194,8 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 		internal.loadAssets();
 		internal.finishLoading();
 
-		// Load the next two images immediately.
-		playButton = null;
-		levelEditorButton = null;
-		calibrationButton = null;
-
-		title = internal.getEntry("title", Texture.class);
 		background = internal.getEntry( "background", Texture.class );
 		background.setFilter( TextureFilter.Linear, TextureFilter.Linear );
-		statusBar = internal.getEntry( "progress", Texture.class );
 
 		// Break up the status bar texture into regions
 		statusBkgLeft = internal.getEntry( "progress.backleft", TextureRegion.class );
@@ -258,14 +208,6 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 
 		// No progress so far.
 		progress = 0;
-		pressState = INITIAL;
-
-		Gdx.input.setInputProcessor( this );
-
-		// Let ANY connected controller start the game.
-		for (XBoxController controller : Controllers.get().getXBoxControllers()) {
-			controller.addListener( this );
-		}
 
 		// Start loading the real assets
 		assets = new AssetDirectory( file );
@@ -302,16 +244,6 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 //		if (playButton == null || levelEditorButton == null) {
 			assets.update(budget);
 			this.progress = assets.getProgress();
-//			if (progress >= 1.0f) {
-//				this.progress = 1.0f;
-//				playButton = internal.getEntry("play",Texture.class);
-//				levelEditorButton = internal.getEntry("level-editor",Texture.class);
-//				calibrationButton = internal.getEntry("play-old",Texture.class);
-//				playButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2 + 200);
-//				levelEditorButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2);
-//				calibrationButtonCoords = new Vector2(centerX + calibrationButton.getWidth()*2 , centerY);
-//			}
-//		}
 	}
 
 	/**
@@ -324,25 +256,7 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	private void draw() {
 		canvas.begin();
 		canvas.draw(background, 0, 0, canvas.getWidth(), canvas.getHeight());
-		if (playButton == null) {
-			drawProgress(canvas);
-		} else {
-			Color playButtonTint = (pressState == PLAY_PRESSED ? Color.GRAY: Color.WHITE);
-			canvas.draw(playButton, playButtonTint, playButton.getWidth()/2, playButton.getHeight()/2,
-					playButtonCoords.x, playButtonCoords.y, 0, BUTTON_SCALE*scale, BUTTON_SCALE*scale);
-
-			Color levelEditorButtonTint = (pressState == LEVEL_EDITOR_PRESSED ? Color.GREEN: Color.WHITE);
-			canvas.draw(levelEditorButton, levelEditorButtonTint, levelEditorButton.getWidth()/2, levelEditorButton.getHeight()/2,
-					levelEditorButtonCoords.x, levelEditorButtonCoords.y, 0, BUTTON_SCALE*scale, BUTTON_SCALE*scale);
-
-			canvas.draw(title, Color.WHITE, title.getWidth()/2, title.getHeight()/2,
-					title.getWidth()/2+50, centerY+300, 0,scale, scale);
-
-			//draw calibration button
-			Color tintCalibration = (pressState == TO_CALIBRATION ? Color.GRAY: Color.RED);
-			canvas.draw(calibrationButton, tintCalibration, calibrationButton.getWidth()/2, calibrationButton.getHeight()/2,
-					calibrationButtonCoords.x, calibrationButtonCoords.y, 0, BUTTON_SCALE*scale, BUTTON_SCALE*scale);
-		}
+		drawProgress(canvas);
 		canvas.end();
 	}
 	
@@ -386,7 +300,7 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 
 			// We are ready, notify our listener
 			if (isReady() && listener != null) {
-				listener.exitScreen(this, 0);
+				listener.exitScreen(this, ExitCode.TO_MENU);
 			}
 		}
 	}
@@ -457,236 +371,4 @@ public class LoadingMode implements Screen, InputProcessor, ControllerListener {
 	public void setScreenListener(ScreenListener listener) {
 		this.listener = listener;
 	}
-	
-	// PROCESSING PLAYER INPUT
-	/**
-	 * Checks to see if the location clicked at `screenX`, `screenY` are within the bounds of the given button
-	 * `buttonTexture` and `buttonCoords` should refer to the appropriate button parameters
-	 *
-	 * @param screenX the x-coordinate of the mouse on the screen
-	 * @param screenY the y-coordinate of the mouse on the screen
-	 * @param buttonTexture the specified button texture
-	 * @param buttonCoords the specified button coordinates as a Vector2 object
-	 * @return whether the button specified was pressed
-	 */
-	public boolean isButtonPressed(int screenX, int screenY, Texture buttonTexture, Vector2 buttonCoords) {
-		// buttons are rectangles
-		// buttonCoords hold the center of the rectangle, buttonTexture has the width and height
-		// get half the x length of the button portrayed
-		float xRadius = BUTTON_SCALE * scale * buttonTexture.getWidth()/2.0f;
-		boolean xInBounds = buttonCoords.x - xRadius <= screenX && buttonCoords.x + xRadius >= screenX;
-
-		// get half the y length of the button portrayed
-		float yRadius = BUTTON_SCALE * scale * buttonTexture.getHeight()/2.0f;
-		boolean yInBounds = buttonCoords.y - yRadius <= screenY && buttonCoords.y + yRadius >= screenY;
-		return xInBounds && yInBounds;
-	}
-
-	/**
-	 * Called when the screen was touched or a mouse button was pressed.
-	 *
-	 * This method checks to see if the play button is available and if the click
-	 * is in the bounds of the play button.  If so, it signals the that the button
-	 * has been pressed and is currently down. Any mouse button is accepted.
-	 *
-	 * @param screenX the x-coordinate of the mouse on the screen
-	 * @param screenY the y-coordinate of the mouse on the screen
-	 * @param pointer the button or touch finger number
-	 * @return whether to hand the event to other listeners. 
-	 */
-	public boolean touchDown(int screenX, int screenY, int pointer, int button) {
-		System.out.println("touched");
-
-		if (playButton == null || pressState == TO_GAME || pressState == TO_LEVEL_EDITOR || pressState == TO_CALIBRATION) {
-			return true;
-		}
-		
-		// Flip to match graphics coordinates
-		screenY = heightY-screenY;
-		
-		// TODO: Fix scaling (?)
-		// check if buttons get pressed appropriately
-		if (isButtonPressed(screenX, screenY, playButton, playButtonCoords)) {
-			pressState = PLAY_PRESSED;
-		}
-		if (isButtonPressed(screenX, screenY, levelEditorButton, levelEditorButtonCoords)) {
-			pressState = LEVEL_EDITOR_PRESSED;
-		}
-
-		float radius = BUTTON_SCALE*scale*calibrationButton.getWidth()/2.0f;
-		float dist = (screenX-calibrationButtonCoords.x)*(screenX-calibrationButtonCoords.x)
-				+(screenY-calibrationButtonCoords.y)*(screenY-calibrationButtonCoords.y);
-		if (dist < radius*radius) {
-			pressState = TO_CALIBRATION;
-		}
-		return false;
-	}
-	
-	/** 
-	 * Called when a finger was lifted or a mouse button was released.
-	 *
-	 * This method checks to see if the play button is currently pressed down. If so, 
-	 * it signals the that the player is ready to go.
-	 *
-	 * @param screenX the x-coordinate of the mouse on the screen
-	 * @param screenY the y-coordinate of the mouse on the screen
-	 * @param pointer the button or touch finger number
-	 * @return whether to hand the event to other listeners. 
-	 */	
-	public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-		switch (pressState){
-			case PLAY_PRESSED:
-				pressState = TO_GAME;
-				return false;
-			case LEVEL_EDITOR_PRESSED:
-				pressState = TO_LEVEL_EDITOR;
-				return false;
-			default:
-				return true;
-		}
-	}
-	
-	/** 
-	 * Called when a button on the Controller was pressed. 
-	 *
-	 * The buttonCode is controller specific. This listener only supports the start
-	 * button on an X-Box controller.  This outcome of this method is identical to 
-	 * pressing (but not releasing) the play button.
-	 *
-	 * @param controller The game controller
-	 * @param buttonCode The button pressed
-	 * @return whether to hand the event to other listeners. 
-	 */
-	public boolean buttonDown (Controller controller, int buttonCode) {
-		// note: does not work for level editor
-		if (pressState == INITIAL) {
-			ControllerMapping mapping = controller.getMapping();
-			if (mapping != null && buttonCode == mapping.buttonStart) {
-				pressState = PLAY_PRESSED;
-				return false;
-			}
-		}
-		return true;
-	}
-	
-	/** 
-	 * Called when a button on the Controller was released. 
-	 *
-	 * The buttonCode is controller specific. This listener only supports the start
-	 * button on an X-Box controller.  This outcome of this method is identical to 
-	 * releasing the the play button after pressing it.
-	 *
-	 * @param controller The game controller
-	 * @param buttonCode The button pressed
-	 * @return whether to hand the event to other listeners. 
-	 */
-	public boolean buttonUp (Controller controller, int buttonCode) {
-		// note: does not work for level editor
-		if (pressState == PLAY_PRESSED) {
-			ControllerMapping mapping = controller.getMapping();
-			if (mapping != null && buttonCode == mapping.buttonStart ) {
-				pressState = TO_GAME;
-				return false;
-			}
-		}
-		return true;
-	}
-	
-	// UNSUPPORTED METHODS FROM InputProcessor
-
-	/** 
-	 * Called when a key is pressed (UNSUPPORTED)
-	 *
-	 * @param keycode the key pressed
-	 * @return whether to hand the event to other listeners. 
-	 */
-	public boolean keyDown(int keycode) { 
-		return true; 
-	}
-
-	/** 
-	 * Called when a key is typed (UNSUPPORTED)
-	 *
-	 * @param keycode the key typed
-	 * @return whether to hand the event to other listeners. 
-	 */
-	public boolean keyTyped(char keycode) {
-		return true; 
-	}
-
-	/** 
-	 * Called when a key is released (UNSUPPORTED)
-	 *
-	 * @param keycode the key released
-	 * @return whether to hand the event to other listeners. 
-	 */	
-	public boolean keyUp(int keycode) { 
-		return true; 
-	}
-	
-	/** 
-	 * Called when the mouse was moved without any buttons being pressed. (UNSUPPORTED)
-	 *
-	 * @param screenX the x-coordinate of the mouse on the screen
-	 * @param screenY the y-coordinate of the mouse on the screen
-	 * @return whether to hand the event to other listeners. 
-	 */	
-	public boolean mouseMoved(int screenX, int screenY) { 
-		return true; 
-	}
-
-	/**
-	 * Called when the mouse wheel was scrolled. (UNSUPPORTED)
-	 *
-	 * @param dx the amount of horizontal scroll
-	 * @param dy the amount of vertical scroll
-	 *
-	 * @return whether to hand the event to other listeners.
-	 */
-	public boolean scrolled(float dx, float dy) {
-		return true;
-	}
-
-	/** 
-	 * Called when the mouse or finger was dragged. (UNSUPPORTED)
-	 *
-	 * @param screenX the x-coordinate of the mouse on the screen
-	 * @param screenY the y-coordinate of the mouse on the screen
-	 * @param pointer the button or touch finger number
-	 * @return whether to hand the event to other listeners. 
-	 */		
-	public boolean touchDragged(int screenX, int screenY, int pointer) { 
-		return true; 
-	}
-	
-	// UNSUPPORTED METHODS FROM ControllerListener
-	
-	/**
-	 * Called when a controller is connected. (UNSUPPORTED)
-	 *
-	 * @param controller The game controller
-	 */
-	public void connected (Controller controller) {}
-
-	/**
-	 * Called when a controller is disconnected. (UNSUPPORTED)
-	 *
-	 * @param controller The game controller
-	 */
-	public void disconnected (Controller controller) {}
-
-	/** 
-	 * Called when an axis on the Controller moved. (UNSUPPORTED) 
-	 *
-	 * The axisCode is controller specific. The axis value is in the range [-1, 1]. 
-	 *
-	 * @param controller The game controller
-	 * @param axisCode 	The axis moved
-	 * @param value 	The axis value, -1 to 1
-	 * @return whether to hand the event to other listeners. 
-	 */
-	public boolean axisMoved (Controller controller, int axisCode, float value) {
-		return true;
-	}
-
 }

--- a/core/src/edu/cornell/gdiac/temporary/MenuMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/MenuMode.java
@@ -78,6 +78,8 @@ public class MenuMode implements Screen, InputProcessor, ControllerListener {
     /** Exit code for the button to go to the level editor */
     public static final int TO_CALIBRATION = 5;
 
+    public static final int TO_MENU = 6;
+
     /**
      * Populates this mode from the given the directory.
      *
@@ -89,11 +91,11 @@ public class MenuMode implements Screen, InputProcessor, ControllerListener {
      */
     public void populate(AssetDirectory directory) {
         logo = directory.getEntry("title", Texture.class);
-        background = directory.getEntry( "background", Texture.class );
+        background = directory.getEntry( "loading-background", Texture.class );
         background.setFilter( Texture.TextureFilter.Linear, Texture.TextureFilter.Linear );
-        playButton = directory.getEntry("play",Texture.class);
-        levelEditorButton = directory.getEntry("level-editor",Texture.class);
-        calibrationButton = directory.getEntry("play-old",Texture.class);
+        playButton = directory.getEntry("play", Texture.class);
+        levelEditorButton = directory.getEntry("level-editor", Texture.class);
+        calibrationButton = directory.getEntry("play-old", Texture.class);
         playButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2 + 200);
         levelEditorButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2);
         calibrationButtonCoords = new Vector2(centerX + calibrationButton.getWidth()*2 , centerY);
@@ -109,6 +111,22 @@ public class MenuMode implements Screen, InputProcessor, ControllerListener {
     }
 
     /**
+     * Getter for the press state of the buttons on the screen
+     * @return value of `pressState`
+     */
+    public int getPressState() {
+        return pressState;
+    }
+
+    /**
+     * Resets the MenuMode
+     */
+    public void reset() {
+        pressState = INITIAL;
+        Gdx.input.setInputProcessor( this );
+    }
+
+    /**
      * Creates a MenuMode
      *
      * @param canvas 	The game canvas to draw to
@@ -117,18 +135,19 @@ public class MenuMode implements Screen, InputProcessor, ControllerListener {
         this.canvas  = canvas;
         // Compute the dimensions from the canvas
         resize(canvas.getWidth(),canvas.getHeight());
-        pressState = INITIAL;
-        Gdx.input.setInputProcessor( this );
+        active = false;
+        reset();
     }
 
     @Override
     public void render(float v) {
         if (active) {
             draw();
-
+            System.out.println("rendering menu");
             // We are ready, notify our listener
+            // TODO: use escape to also quit the game
             if (isReady() && listener != null) {
-                listener.exitScreen(this, 0);
+                listener.exitScreen(this, 1);
             }
         }
     }
@@ -197,7 +216,7 @@ public class MenuMode implements Screen, InputProcessor, ControllerListener {
 
     @Override
     public void dispose() {
-
+        canvas = null;
     }
 
     /**

--- a/core/src/edu/cornell/gdiac/temporary/MenuMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/MenuMode.java
@@ -1,0 +1,238 @@
+package edu.cornell.gdiac.temporary;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.math.Vector2;
+import edu.cornell.gdiac.assets.AssetDirectory;
+import edu.cornell.gdiac.util.ScreenListener;
+
+/**
+ * This class is just a ported over LoadingMode without the asset loading part, only the menu part
+ */
+public class MenuMode implements Screen, InputProcessor {
+
+    /** Reference to GameCanvas created by the root */
+    private GameCanvas canvas;
+    /** Listener that will update the player mode when we are done */
+    private ScreenListener listener;
+    /** Whether or not this player mode is still active */
+    private boolean active;
+
+    /** Background texture */
+    private Texture background;
+    /** Tempo-Rary logo */
+    private Texture logo;
+    /** Buttons */
+    private Texture playButton;
+    private Texture calibrationButton;
+    private Texture levelEditorButton;
+
+    /* BUTTON LOCATIONS */
+    /** Play button x and y coordinates represented as a vector */
+    private Vector2 playButtonCoords;
+    /** Level editor button x and y coordinates represented as a vector */
+    private Vector2 levelEditorButtonCoords;
+    /** Calibration button x and y coordinates represented as a vector */
+    private Vector2 calibrationButtonCoords;
+    /** Scale at which to draw the buttons */
+    private static float BUTTON_SCALE  = 0.75f;
+    /** The y-coordinate of the center of the progress bar (artifact of LoadingMode) */
+    private int centerY;
+    /** The x-coordinate of the center of the progress bar (artifact of LoadingMode) */
+    private int centerX;
+
+    /** Standard window size (for scaling) */
+    private static int STANDARD_WIDTH  = 1200;
+    /** Standard window height (for scaling) */
+    private static int STANDARD_HEIGHT = 800;
+    /** Ratio of the bar width to the screen (artifact of LoadingMode) */
+    private static float BAR_WIDTH_RATIO  = 0.66f;
+    /** Ration of the bar height to the screen (artifact of LoadingMode) */
+    private static float BAR_HEIGHT_RATIO = 0.25f;
+    /** Scaling factor for when the student changes the resolution. */
+    private float scale;
+
+    /** The current state of each button */
+    private int pressState;
+
+    /* PRESS STATES **/
+    // TODO: potentially change this to enums
+    /** Initial button state */
+    private static final int INITIAL = 0;
+    /** Pressed down button state for the play button */
+    private static final int PLAY_PRESSED = 1;
+    /** Exit code for button to go to the game */
+    public static final int TO_GAME = 2;
+    /** Pressed down button state for the level editor button */
+    private static final int LEVEL_EDITOR_PRESSED = 3;
+    /** Exit code for the button to go to the level editor */
+    public static final int TO_LEVEL_EDITOR = 4;
+    /** Exit code for the button to go to the level editor */
+    public static final int TO_CALIBRATION = 5;
+
+    /**
+     * Populates this mode from the given the directory.
+     *
+     * The asset directory is a dictionary that maps string keys to assets.
+     * Assets can include images, sounds, and fonts (and more). This
+     * method delegates to the gameplay controller
+     *
+     * @param directory 	Reference to the asset directory.
+     */
+    public void populate(AssetDirectory directory) {
+        logo = directory.getEntry("title", Texture.class);
+        background = directory.getEntry( "background", Texture.class );
+        background.setFilter( Texture.TextureFilter.Linear, Texture.TextureFilter.Linear );
+        playButton = directory.getEntry("play",Texture.class);
+        levelEditorButton = directory.getEntry("level-editor",Texture.class);
+        calibrationButton = directory.getEntry("play-old",Texture.class);
+        playButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2 + 200);
+        levelEditorButtonCoords = new Vector2(centerX + levelEditorButton.getWidth(), canvas.getHeight()/2);
+        calibrationButtonCoords = new Vector2(centerX + calibrationButton.getWidth()*2 , centerY);
+    }
+
+    /**
+     * Returns true if all assets are loaded and the player presses on a button
+     *
+     * @return true if the player is ready to go
+     */
+    public boolean isReady() {
+        return pressState == TO_GAME || pressState == TO_LEVEL_EDITOR || pressState == TO_CALIBRATION;
+    }
+
+    /**
+     * Creates a MenuMode
+     *
+     * @param canvas 	The game canvas to draw to
+     */
+    public MenuMode(GameCanvas canvas) {
+        this.canvas  = canvas;
+        // Compute the dimensions from the canvas
+        resize(canvas.getWidth(),canvas.getHeight());
+        pressState = INITIAL;
+        Gdx.input.setInputProcessor( this );
+    }
+
+    @Override
+    public void render(float v) {
+        if (active) {
+            draw();
+
+            // We are ready, notify our listener
+            if (isReady() && listener != null) {
+                listener.exitScreen(this, 0);
+            }
+        }
+    }
+
+    /**
+     * Draw the status of this player mode.
+     *
+     * We prefer to separate update and draw from one another as separate methods, instead
+     * of using the single render() method that LibGDX does.  We will talk about why we
+     * prefer this in lecture.
+     */
+    private void draw() {
+        canvas.begin();
+        canvas.draw(background, 0, 0, canvas.getWidth(), canvas.getHeight());
+        Color playButtonTint = (pressState == PLAY_PRESSED ? Color.GRAY: Color.WHITE);
+        canvas.draw(playButton, playButtonTint, playButton.getWidth()/2, playButton.getHeight()/2,
+                    playButtonCoords.x, playButtonCoords.y, 0, BUTTON_SCALE*scale, BUTTON_SCALE*scale);
+
+        Color levelEditorButtonTint = (pressState == LEVEL_EDITOR_PRESSED ? Color.GREEN: Color.WHITE);
+        canvas.draw(levelEditorButton, levelEditorButtonTint, levelEditorButton.getWidth()/2, levelEditorButton.getHeight()/2,
+                    levelEditorButtonCoords.x, levelEditorButtonCoords.y, 0, BUTTON_SCALE*scale, BUTTON_SCALE*scale);
+
+        canvas.draw(logo, Color.WHITE, logo.getWidth()/2, logo.getHeight()/2,
+                    logo.getWidth()/2+50, centerY+300, 0,scale, scale);
+
+        //draw calibration button
+        Color tintCalibration = (pressState == TO_CALIBRATION ? Color.GRAY: Color.RED);
+        canvas.draw(calibrationButton, tintCalibration, calibrationButton.getWidth()/2, calibrationButton.getHeight()/2,
+                    calibrationButtonCoords.x, calibrationButtonCoords.y, 0, BUTTON_SCALE*scale, BUTTON_SCALE*scale);
+        canvas.end();
+    }
+
+    // TODO: fix this method
+    @Override
+    public void resize(int width, int height) {
+        // Compute the drawing scale
+        float sx = ((float)width)/STANDARD_WIDTH;
+        float sy = ((float)height)/STANDARD_HEIGHT;
+        scale = (sx < sy ? sx : sy);
+
+//        this.width = (int)(BAR_WIDTH_RATIO*width);
+        centerY = (int)(BAR_HEIGHT_RATIO*height);
+        centerX = width/2;
+//        heightY = height;
+    }
+
+    @Override
+    public void pause() {
+
+    }
+
+    @Override
+    public void resume() {
+
+    }
+
+    @Override
+    public void show() {
+        active = true;
+    }
+
+    @Override
+    public void hide() {
+        active = false;
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+
+    // PROCESSING PLAYER INPUT
+    @Override
+    public boolean keyDown(int i) {
+        return false;
+    }
+
+    @Override
+    public boolean keyUp(int i) {
+        return false;
+    }
+
+    @Override
+    public boolean keyTyped(char c) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDown(int i, int i1, int i2, int i3) {
+        return false;
+    }
+
+    @Override
+    public boolean touchUp(int i, int i1, int i2, int i3) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDragged(int i, int i1, int i2) {
+        return false;
+    }
+
+    @Override
+    public boolean mouseMoved(int i, int i1) {
+        return false;
+    }
+
+    @Override
+    public boolean scrolled(float v, float v1) {
+        return false;
+    }
+}

--- a/core/src/edu/cornell/gdiac/temporary/editor/EditorMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/editor/EditorMode.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.graphics.*;
 import edu.cornell.gdiac.assets.AssetDirectory;
 import edu.cornell.gdiac.temporary.GameCanvas;
 import edu.cornell.gdiac.temporary.InputController;
+import edu.cornell.gdiac.temporary.MenuMode;
 import edu.cornell.gdiac.util.FilmStrip;
 import edu.cornell.gdiac.util.ScreenListener;
 import edu.cornell.gdiac.audio.*;
@@ -778,10 +779,6 @@ public class EditorMode implements Screen {
             note.setY(songPosToScreenY(note.getPos()));
             note.setOnScreen(onScreen(note.getPos()));
         }
-
-        if (inputController.didExit()) {
-            listener.exitScreen(this, 0);
-        }
     }
 
     /**
@@ -1369,7 +1366,8 @@ public class EditorMode implements Screen {
             update(delta);
             draw(delta);
             if (inputController.didExit() && listener != null) {
-                listener.exitScreen(this, 0);
+                System.out.println("leaving the editor");
+                listener.exitScreen(this, MenuMode.TO_MENU);
             }
         }
     }

--- a/core/src/edu/cornell/gdiac/temporary/editor/EditorMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/editor/EditorMode.java
@@ -1,7 +1,6 @@
 package edu.cornell.gdiac.temporary.editor;
 
 import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.math.Vector2;
@@ -9,9 +8,9 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.*;
 
 import edu.cornell.gdiac.assets.AssetDirectory;
+import edu.cornell.gdiac.temporary.ExitCode;
 import edu.cornell.gdiac.temporary.GameCanvas;
 import edu.cornell.gdiac.temporary.InputController;
-import edu.cornell.gdiac.temporary.MenuMode;
 import edu.cornell.gdiac.util.FilmStrip;
 import edu.cornell.gdiac.util.ScreenListener;
 import edu.cornell.gdiac.audio.*;
@@ -1366,8 +1365,7 @@ public class EditorMode implements Screen {
             update(delta);
             draw(delta);
             if (inputController.didExit() && listener != null) {
-                System.out.println("leaving the editor");
-                listener.exitScreen(this, MenuMode.TO_MENU);
+                listener.exitScreen(this, ExitCode.TO_MENU);
             }
         }
     }


### PR DESCRIPTION
## Summary <!-- Required -->

This pull request implements the `MenuMode` class, which decouples showing the menu screen from appearing in the loading screen, as well as adds `ExitCode` helper class holding a bunch of constants for help in screen switching. This removes the need for reinstantiating `LoadingMode` every time and will also help with adding more screens down the line. 

- [x] implemented `MenuMode`
- [x] removed input interfacing in `LoadingMode`
- [x] set up screen switching with `ExitCode`

## Notes <!-- Optional -->

Notion writeup for this if you are implementing screens: https://www.notion.so/mluo/Screen-Switching-c4046fe85e4444c996ced069f9c1a7e6?pvs=4