### PR TITLE
Background scaling

### DIFF
--- a/assets/levels/american-easy.json
+++ b/assets/levels/american-easy.json
@@ -1,17 +1,17 @@
 {
-  "levelname" : "America",
+  "levelname" : "American",
   "background" : "cafe-background",
   "levelNumber" : 9,
   "song" : "American",
   "startPosition" : 0,
   "bpm" : 160,
-  "maxCompetency" : 100,
+  "maxCompetency" :20,
   "linesPerMember" : 4,
-  "a-threshold":40000,"b-threshold":30000,"c-threshold":20000,"s-threshold":50000,
+  "a-threshold":660000,"b-threshold":520000,"c-threshold":300000,"s-threshold":715000,
   "bandMembers" : [
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "held",
@@ -327,7 +327,7 @@
         },
         {
           "type" : "switch",
-          "position" : 1179000,
+          "position" : 1152000,
           "duration" : 0,
           "line" : -1
         },
@@ -463,7 +463,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",
@@ -1263,7 +1263,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",
@@ -1899,7 +1899,7 @@
           "type" : "held",
           "position" : 4536000,
           "duration" : 18000,
-          "line" : 3
+          "line" : 2
         },
         {
           "type" : "held",
@@ -1913,17 +1913,11 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
-          "type" : "beat",
-          "position" : 2232000,
-          "duration" : 0,
-          "line" : 0
-        },
-        {
           "type" : "switch",
-          "position" : 2259000,
+          "position" : 2232000,
           "duration" : 0,
           "line" : -1
         },

--- a/assets/levels/american-hard.json
+++ b/assets/levels/american-hard.json
@@ -1,17 +1,17 @@
 {
   "levelname" : "American",
-  "background" : "cafe-background",
+  "background" : "mountain-background",
   "levelNumber" : 9,
   "song" : "American",
   "startPosition" : 0,
   "bpm" : 160,
-  "maxCompetency" : 20,
+  "maxCompetency" :20,
   "linesPerMember" : 4,
-  "a-threshold":40000,"b-threshold":30000,"c-threshold":20000,"s-threshold":50000,
+  "a-threshold":660000,"b-threshold":520000,"c-threshold":300000,"s-threshold":715000,
   "bandMembers" : [
     {
       "instrument" : "piano",
-      "competencyLossRate" : 2,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "held",
@@ -463,7 +463,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 2,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",
@@ -1263,7 +1263,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 2,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",
@@ -1899,7 +1899,7 @@
           "type" : "held",
           "position" : 4536000,
           "duration" : 18000,
-          "line" : 3
+          "line" : 2
         },
         {
           "type" : "held",
@@ -1913,7 +1913,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 2,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",

--- a/assets/levels/american-hard.json
+++ b/assets/levels/american-hard.json
@@ -1,6 +1,6 @@
 {
   "levelname" : "American",
-  "background" : "mountain-background",
+  "background" : "cafe-background",
   "levelNumber" : 9,
   "song" : "American",
   "startPosition" : 0,

--- a/assets/levels/american-medium.json
+++ b/assets/levels/american-medium.json
@@ -1,17 +1,17 @@
 {
-  "levelname" : "America",
+  "levelname" : "American",
   "background" : "cafe-background",
   "levelNumber" : 9,
   "song" : "American",
   "startPosition" : 0,
   "bpm" : 160,
-  "maxCompetency" : 100,
+  "maxCompetency" :20,
   "linesPerMember" : 4,
-  "a-threshold":40000,"b-threshold":30000,"c-threshold":20000,"s-threshold":50000,
+  "a-threshold":660000,"b-threshold":520000,"c-threshold":300000,"s-threshold":715000,
   "bandMembers" : [
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "held",
@@ -327,7 +327,7 @@
         },
         {
           "type" : "switch",
-          "position" : 1179000,
+          "position" : 1152000,
           "duration" : 0,
           "line" : -1
         },
@@ -463,7 +463,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",
@@ -1263,7 +1263,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
           "type" : "switch",
@@ -1899,7 +1899,7 @@
           "type" : "held",
           "position" : 4536000,
           "duration" : 18000,
-          "line" : 3
+          "line" : 2
         },
         {
           "type" : "held",
@@ -1913,17 +1913,11 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" :2,
       "notes" : [
         {
-          "type" : "beat",
-          "position" : 2232000,
-          "duration" : 0,
-          "line" : 0
-        },
-        {
           "type" : "switch",
-          "position" : 2259000,
+          "position" : 2232000,
           "duration" : 0,
           "line" : -1
         },

--- a/assets/levels/yr-hard.json
+++ b/assets/levels/yr-hard.json
@@ -5,9 +5,9 @@
   "song" : "YR",
   "startPosition" : 0,
   "bpm" : 150,
-  "maxCompetency" : 30,
+  "maxCompetency" : 100,
   "linesPerMember" : 4,
-  "a-threshold":650000,"b-threshold":450000,"c-threshold":300000,"s-threshold":700000,
+  "a-threshold":700000,"b-threshold":600000,"c-threshold":400000,"s-threshold":750000,
   "bandMembers" : [
     {
       "instrument" : "piano",
@@ -828,12 +828,6 @@
           "position" : 2688000,
           "duration" : 38400,
           "line" : 2
-        },
-        {
-          "type" : "beat",
-          "position" : 2688000,
-          "duration" : 0,
-          "line" : 1
         },
         {
           "type" : "beat",
@@ -2487,12 +2481,6 @@
           "type" : "held",
           "position" : 3724800,
           "duration" : 28800,
-          "line" : 3
-        },
-        {
-          "type" : "held",
-          "position" : 3724800,
-          "duration" : 28800,
           "line" : 2
         },
         {
@@ -3432,12 +3420,6 @@
           "position" : 2304000,
           "duration" : 0,
           "line" : 2
-        },
-        {
-          "type" : "beat",
-          "position" : 2304000,
-          "duration" : 0,
-          "line" : 0
         },
         {
           "type" : "beat",

--- a/assets/levels/yr-hard.json
+++ b/assets/levels/yr-hard.json
@@ -5,13 +5,13 @@
   "song" : "YR",
   "startPosition" : 0,
   "bpm" : 150,
-  "maxCompetency" : 100,
+  "maxCompetency" : 175,
   "linesPerMember" : 4,
-  "a-threshold":700000,"b-threshold":600000,"c-threshold":400000,"s-threshold":750000,
+  "a-threshold":640000,"b-threshold":530000,"c-threshold":320000,"s-threshold":750000,
   "bandMembers" : [
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" : 15,
       "notes" : [
         {
           "type" : "beat",
@@ -633,21 +633,9 @@
         },
         {
           "type" : "switch",
-          "position" : 2491200,
+          "position" : 2496000,
           "duration" : 0,
           "line" : -1
-        },
-        {
-          "type" : "beat",
-          "position" : 2502400,
-          "duration" : 0,
-          "line" : 1
-        },
-        {
-          "type" : "beat",
-          "position" : 2508800,
-          "duration" : 0,
-          "line" : 2
         },
         {
           "type" : "beat",
@@ -1153,7 +1141,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" : 15,
       "notes" : [
         {
           "type" : "switch",
@@ -1271,12 +1259,6 @@
         },
         {
           "type" : "beat",
-          "position" : 2931200,
-          "duration" : 0,
-          "line" : 0
-        },
-        {
-          "type" : "beat",
           "position" : 2937600,
           "duration" : 0,
           "line" : 3
@@ -1331,12 +1313,6 @@
         },
         {
           "type" : "beat",
-          "position" : 3084800,
-          "duration" : 0,
-          "line" : 3
-        },
-        {
-          "type" : "beat",
           "position" : 3091200,
           "duration" : 0,
           "line" : 0
@@ -1358,12 +1334,6 @@
           "position" : 3148800,
           "duration" : 0,
           "line" : -1
-        },
-        {
-          "type" : "beat",
-          "position" : 3161600,
-          "duration" : 0,
-          "line" : 3
         },
         {
           "type" : "beat",
@@ -1478,18 +1448,6 @@
           "position" : 3353600,
           "duration" : 0,
           "line" : 1
-        },
-        {
-          "type" : "beat",
-          "position" : 3360000,
-          "duration" : 0,
-          "line" : 2
-        },
-        {
-          "type" : "beat",
-          "position" : 3360000,
-          "duration" : 0,
-          "line" : 0
         },
         {
           "type" : "switch",
@@ -1827,7 +1785,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" : 15,
       "notes" : [
         {
           "type" : "switch",
@@ -2257,7 +2215,7 @@
         },
         {
           "type" : "switch",
-          "position" : 3372800,
+          "position" : 3360000,
           "duration" : 0,
           "line" : -1
         },
@@ -2807,7 +2765,7 @@
   ,
     {
       "instrument" : "piano",
-      "competencyLossRate" : 1,
+      "competencyLossRate" : 15,
       "notes" : [
         {
           "type" : "switch",
@@ -3615,21 +3573,9 @@
         },
         {
           "type" : "switch",
-          "position" : 2835200,
+          "position" : 2841600,
           "duration" : 0,
           "line" : -1
-        },
-        {
-          "type" : "beat",
-          "position" : 2848000,
-          "duration" : 0,
-          "line" : 0
-        },
-        {
-          "type" : "beat",
-          "position" : 2854400,
-          "duration" : 0,
-          "line" : 1
         },
         {
           "type" : "beat",
@@ -3753,12 +3699,6 @@
         },
         {
           "type" : "beat",
-          "position" : 3123200,
-          "duration" : 0,
-          "line" : 1
-        },
-        {
-          "type" : "beat",
           "position" : 3129600,
           "duration" : 0,
           "line" : 3
@@ -3780,12 +3720,6 @@
           "position" : 3187200,
           "duration" : 0,
           "line" : -1
-        },
-        {
-          "type" : "beat",
-          "position" : 3200000,
-          "duration" : 0,
-          "line" : 1
         },
         {
           "type" : "beat",

--- a/core/src/edu/cornell/gdiac/temporary/CalibrationMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/CalibrationMode.java
@@ -337,7 +337,10 @@ public class CalibrationMode implements Screen {
         inputController = null;
         canvas = null;
         // TODO: dispose all assets
-        music.dispose();
+        if (music != null){
+            music.dispose();
+        }
+
     }
 
     /**

--- a/core/src/edu/cornell/gdiac/temporary/GDXRoot.java
+++ b/core/src/edu/cornell/gdiac/temporary/GDXRoot.java
@@ -153,9 +153,7 @@ public class GDXRoot extends Game implements ScreenListener {
 			loading = null;
 		}
 		else if (exitCode == ExitCode.TO_LEVEL) {
-
 			screen.hide();
-			System.out.println("hello");
 			levelscreen.reset();
 			levelscreen.setScreenListener(this);
 			levelscreen.populate(directory);

--- a/core/src/edu/cornell/gdiac/temporary/GameCanvas.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameCanvas.java
@@ -321,10 +321,14 @@ public class GameCanvas {
 			return;
 		}
 
+		//When drawing we must maintain aspect ratio.
+		//To do this effectively we determine which variable to scale by.
 
-
-        // Have to draw the background twice for continuous scrolling.
-        spriteBatch.draw(image, x,   y, getWidth(), getHeight());
+		float ratio = (image.getHeight()/(float)image.getWidth())/(getHeight()/(float)getWidth());
+		float scale = ratio >= 1 ? getWidth()/(float)image.getWidth() : getHeight()/(float)image.getHeight();
+		float trueW = image.getWidth()*scale;
+		float trueH = image.getHeight()*scale;
+        spriteBatch.draw(image, x,   y, trueW, trueH);
 
     }
 

--- a/core/src/edu/cornell/gdiac/temporary/GameCanvas.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameCanvas.java
@@ -328,7 +328,10 @@ public class GameCanvas {
 		float scale = ratio >= 1 ? getWidth()/(float)image.getWidth() : getHeight()/(float)image.getHeight();
 		float trueW = image.getWidth()*scale;
 		float trueH = image.getHeight()*scale;
-        spriteBatch.draw(image, x,   y, trueW, trueH);
+		float tlx = x - (trueW - getWidth())/2f;
+		float tly = y - (trueH - getHeight())/2f;
+
+        spriteBatch.draw(image, tlx,   tly, trueW, trueH);
 
     }
 

--- a/core/src/edu/cornell/gdiac/temporary/GameMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameMode.java
@@ -453,11 +453,7 @@ public class GameMode implements Screen {
 					gameplayController.update(0, ticks);
 				}
 				if (introTime >= 0) {
-					for (boolean k : inputController.didTrigger()){
-						if (k) {
-							gameplayController.sfx.playSound("tap", 0.2f);
-						}
-					}
+					gameplayController.handleActions(inputController);
 				}
 				if (introTime >= 0 && !saidThree){
 					introThreeSFX.playSound("three", 0.3f);
@@ -470,6 +466,7 @@ public class GameMode implements Screen {
 				if (introTime >= 200 && !saidOne){
 					introOneSFX.playSound("one", 0.3f);
 					saidOne = true;
+					gameplayController.handleActions(inputController);
 				}
 				if (introTime >= 300) {
 					introGoSFX.playSound("go", 0.3f);

--- a/core/src/edu/cornell/gdiac/temporary/GameMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameMode.java
@@ -302,7 +302,9 @@ public class GameMode implements Screen {
 	 */
 	public void dispose() {
 		inputController = null;
-		gameplayController.dispose();
+		if(gameplayController!=null){
+			gameplayController.dispose();
+		}
 		gameplayController = null;
 		canvas = null;
 	}

--- a/core/src/edu/cornell/gdiac/temporary/GameplayController.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameplayController.java
@@ -810,10 +810,17 @@ public class GameplayController {
 	}
 
 	public void dispose(){
-		level.dispose();
-		level = null;
-		sfx.dispose();
-		sb.dispose();
+		if(level!=null){
+			level.dispose();
+			level = null;
+		}
+		if(sfx!=null){
+			sfx.dispose();
+		}
+		if(sb !=null){
+			sb.dispose();
+		}
+
 		garbageCollectNoteIndicators();
 	}
 }

--- a/core/src/edu/cornell/gdiac/temporary/GameplayController.java
+++ b/core/src/edu/cornell/gdiac/temporary/GameplayController.java
@@ -424,7 +424,7 @@ public class GameplayController {
 	public int updateIntro(int frame){
 		//start countdown after 2 seconds.
 		if (frame >= 120) {
-			float countTime = (1f / 1f) * level.getAnimationRateFromBPM(level.getBpm());
+			float countTime = level.getAnimationRateFromBPM(level.getBpm());
 			//if we notice bpm is too fast, half the speed so its one count every 2 beats
 			if (countTime >= 1f / 20f) {
 				countTime = countTime * (1f / 2f);
@@ -438,7 +438,7 @@ public class GameplayController {
 	 * @return length (in frames) of the intro sequence
 	 */
 	public int getIntroLength(){
-		float countTime = (1f / 1f) * level.getAnimationRateFromBPM(level.getBpm());
+		float countTime = level.getAnimationRateFromBPM(level.getBpm());
 		if (countTime >= 1f / 20f) {
 			countTime = countTime * (1f / 2f);
 		}
@@ -716,7 +716,7 @@ public class GameplayController {
 		}
 
 		boolean[] lifted = input.triggerLifted;
-		long currentSample = level.getCurrentSample();
+		long currentSample = level.getLevelSample();
 
 		//This array tells us if a hit has already been registered in this frame for the ith bm.
 		//We do not want one hit to count for two notes that are close together.

--- a/core/src/edu/cornell/gdiac/temporary/Level.java
+++ b/core/src/edu/cornell/gdiac/temporary/Level.java
@@ -554,6 +554,10 @@ public class Level {
         return (long)(music.getPosition()*music.getSampleRate());
     }
 
+    public long getLevelSample(){
+        return sample;
+    }
+
     /**
      * Returns true if the player has unlocked this level
      * @return

--- a/core/src/edu/cornell/gdiac/temporary/MenuMode.java
+++ b/core/src/edu/cornell/gdiac/temporary/MenuMode.java
@@ -724,7 +724,7 @@ public class MenuMode implements Screen, InputProcessor, ControllerListener {
     @Override
     public void dispose() {
         canvas = null;
-        stage.dispose();
+        stage = null;
     }
 
     /**


### PR DESCRIPTION
Backgrounds now preserve their aspect ratio, with the trade off that some of the background might be cut off. The scaling is done such that there will be no blank space, and the total area of the background cut off is minimized. The backgrounds will remain centered.

fixed inputs during 3 2 1 Go, we can now hit notes during the count down

Balanced the thresholds and competency on YR and AMER levels


